### PR TITLE
Add customizable app name

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ $ cd Administrivia
 $ bundle exec guard # Run guard to auto run test/s
 ```
 
+## Setup
+
+### Setup settings
+
+Custom settings are available inside the `config/initializers/administrivia.rb` file.
+
 ## License
 
 MIT © [Neil Kim Gardose](https://github.com/nkpgardose)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,6 +1,6 @@
 module ApplicationHelper
   def full_title(content = '')
-    full_title = 'Administrivia'
+    full_title = Rails.configuration.x.name
     if content.present?
       "#{content} · #{full_title}"
     else

--- a/config/initializers/administrivia.rb
+++ b/config/initializers/administrivia.rb
@@ -1,0 +1,4 @@
+Rails.application.configure do
+  # Your custom app name
+  config.x.name = "Administrivia"
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -12,3 +12,7 @@ class ActiveSupport::TestCase
   # Add more helper methods to be used by all tests here...
   include ApplicationHelper
 end
+
+Rails.application.configure do
+  config.x.name = "Administrivia"
+end


### PR DESCRIPTION
Add configurable app name. This adds the `Rails.configuration.x.name` setting so that users are able to change the app's name.
